### PR TITLE
Dockerfile:* Make $JAVA_HOME/lib/security/cacerts writable by GID 0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -128,8 +128,8 @@ RUN echo 'networkaddress.cache.negative.ttl=0' >> $JAVA_HOME/lib/security/java.s
 RUN ln $PRESTO_CLI /usr/local/bin/presto-cli \
         && chmod 755 /usr/local/bin/presto-cli
 
-RUN chown -R 1003:0 /opt/presto /etc/passwd && \
-    chmod -R 774 /etc/passwd && \
+RUN chown -R 1003:0 /opt/presto /etc/passwd $JAVA_HOME/lib/security/cacerts && \
+    chmod -R 774 /etc/passwd $JAVA_HOME/lib/security/cacerts && \
     chmod -R 775 /opt/presto
 
 USER 1003

--- a/Dockerfile
+++ b/Dockerfile
@@ -78,7 +78,7 @@ RUN cd /build/presto-server && mvn -B -e -T 1C -DskipTests -DfailIfNoTests=false
 # Install presto-cli
 RUN cd /build/presto-cli && mvn -B -e -T 1C -DskipTests -DfailIfNoTests=false -Dtest=false package
 # Install prometheus-jmx agent
-RUN mvn dependency:get -Dartifact=io.prometheus.jmx:jmx_prometheus_javaagent:0.3.1:jar -Ddest=/build/jmx_prometheus_javaagent.jar
+RUN mvn -B dependency:get -Dartifact=io.prometheus.jmx:jmx_prometheus_javaagent:0.3.1:jar -Ddest=/build/jmx_prometheus_javaagent.jar
 
 FROM centos:7
 

--- a/Dockerfile.okd
+++ b/Dockerfile.okd
@@ -128,8 +128,8 @@ RUN echo 'networkaddress.cache.negative.ttl=0' >> $JAVA_HOME/lib/security/java.s
 RUN ln $PRESTO_CLI /usr/local/bin/presto-cli \
         && chmod 755 /usr/local/bin/presto-cli
 
-RUN chown -R 1003:0 /opt/presto /etc/passwd && \
-    chmod -R 774 /etc/passwd && \
+RUN chown -R 1003:0 /opt/presto /etc/passwd $JAVA_HOME/lib/security/cacerts && \
+    chmod -R 774 /etc/passwd $JAVA_HOME/lib/security/cacerts && \
     chmod -R 775 /opt/presto
 
 USER 1003

--- a/Dockerfile.okd
+++ b/Dockerfile.okd
@@ -78,7 +78,7 @@ RUN cd /build/presto-server && mvn -B -e -T 1C -DskipTests -DfailIfNoTests=false
 # Install presto-cli
 RUN cd /build/presto-cli && mvn -B -e -T 1C -DskipTests -DfailIfNoTests=false -Dtest=false package
 # Install prometheus-jmx agent
-RUN mvn dependency:get -Dartifact=io.prometheus.jmx:jmx_prometheus_javaagent:0.3.1:jar -Ddest=/build/jmx_prometheus_javaagent.jar
+RUN mvn -B dependency:get -Dartifact=io.prometheus.jmx:jmx_prometheus_javaagent:0.3.1:jar -Ddest=/build/jmx_prometheus_javaagent.jar
 
 FROM registry.access.redhat.com/ubi7/ubi
 

--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -74,8 +74,8 @@ COPY --from=build /build/jmx_prometheus_javaagent.jar $PROMETHEUS_JMX_EXPORTER
 RUN ln $PRESTO_CLI /usr/local/bin/presto-cli \
         && chmod 755 /usr/local/bin/presto-cli
 
-RUN chown -R 1003:0 /opt/presto /etc/passwd && \
-    chmod -R 774 /etc/passwd && \
+RUN chown -R 1003:0 /opt/presto /etc/passwd $JAVA_HOME/lib/security/cacerts && \
+    chmod -R 774 /etc/passwd $JAVA_HOME/lib/security/cacerts && \
     chmod -R 775 /opt/presto
 
 USER 1003


### PR DESCRIPTION
In openshift, a container's user gets GID 0 so this will allow our pod to add to it's truststore from a secret containing extra CA's to trust.