### PR TITLE
Pushdown predicate

### DIFF
--- a/presto-prometheus/src/main/java/io/prestosql/plugin/prometheus/PrometheusMetadata.java
+++ b/presto-prometheus/src/main/java/io/prestosql/plugin/prometheus/PrometheusMetadata.java
@@ -23,6 +23,8 @@ import io.prestosql.spi.connector.ConnectorSession;
 import io.prestosql.spi.connector.ConnectorTableHandle;
 import io.prestosql.spi.connector.ConnectorTableMetadata;
 import io.prestosql.spi.connector.ConnectorTableProperties;
+import io.prestosql.spi.connector.Constraint;
+import io.prestosql.spi.connector.ConstraintApplicationResult;
 import io.prestosql.spi.connector.SchemaTableName;
 import io.prestosql.spi.connector.SchemaTablePrefix;
 import io.prestosql.spi.connector.TableNotFoundException;
@@ -166,5 +168,12 @@ public class PrometheusMetadata
     public ConnectorTableProperties getTableProperties(ConnectorSession session, ConnectorTableHandle table)
     {
         return new ConnectorTableProperties();
+    }
+
+    @Override
+    public Optional<ConstraintApplicationResult<ConnectorTableHandle>> applyFilter(ConnectorSession session, ConnectorTableHandle handle, Constraint constraint)
+    {
+        prometheusClient.setPredicate(Optional.of(constraint.getSummary()));
+        return Optional.empty();
     }
 }

--- a/presto-prometheus/src/main/java/io/prestosql/plugin/prometheus/PrometheusPredicateTimeInfo.java
+++ b/presto-prometheus/src/main/java/io/prestosql/plugin/prometheus/PrometheusPredicateTimeInfo.java
@@ -1,25 +1,20 @@
 /*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *  * Licensed under the Apache License, Version 2.0 (the "License");
- *  * you may not use this file except in compliance with the License.
- *  * You may obtain a copy of the License at
- *  *
- *  *     http://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  * Unless required by applicable law or agreed to in writing, software
- *  * distributed under the License is distributed on an "AS IS" BASIS,
- *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  * See the License for the specific language governing permissions and
- *  * limitations under the License.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package io.prestosql.plugin.prometheus;
 
 import java.time.ZonedDateTime;
 import java.util.Optional;
-
-import static java.util.Objects.requireNonNull;
 
 public class PrometheusPredicateTimeInfo
 {
@@ -54,9 +49,8 @@ public class PrometheusPredicateTimeInfo
 
     public static final class Builder
     {
-
-        Optional<ZonedDateTime> predicateLowerTimeBound;
-        Optional<ZonedDateTime> predicateUpperTimeBound;
+        Optional<ZonedDateTime> predicateLowerTimeBound = Optional.empty();
+        Optional<ZonedDateTime> predicateUpperTimeBound = Optional.empty();
 
         public Builder()
         {
@@ -71,8 +65,6 @@ public class PrometheusPredicateTimeInfo
 
         public PrometheusPredicateTimeInfo build()
         {
-            requireNonNull(predicateLowerTimeBound, "must set a lower time bound for predicate time info");
-            requireNonNull(predicateUpperTimeBound, "must set a upper time bound for predicate time info");
             return new PrometheusPredicateTimeInfo(this);
         }
     }

--- a/presto-prometheus/src/main/java/io/prestosql/plugin/prometheus/PrometheusPredicateTimeInfo.java
+++ b/presto-prometheus/src/main/java/io/prestosql/plugin/prometheus/PrometheusPredicateTimeInfo.java
@@ -1,0 +1,79 @@
+/*
+ *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package io.prestosql.plugin.prometheus;
+
+import java.time.ZonedDateTime;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public class PrometheusPredicateTimeInfo
+{
+    Optional<ZonedDateTime> predicateLowerTimeBound;
+    Optional<ZonedDateTime> predicateUpperTimeBound;
+
+    private PrometheusPredicateTimeInfo(Builder builder)
+    {
+        predicateLowerTimeBound = builder.predicateLowerTimeBound;
+        predicateUpperTimeBound = builder.predicateUpperTimeBound;
+    }
+
+    public Optional<ZonedDateTime> getPredicateLowerTimeBound()
+    {
+        return predicateLowerTimeBound;
+    }
+
+    public Optional<ZonedDateTime> getPredicateUpperTimeBound()
+    {
+        return predicateUpperTimeBound;
+    }
+
+    public Builder toBuilder()
+    {
+        return new Builder(this);
+    }
+
+    public static Builder builder()
+    {
+        return new Builder();
+    }
+
+    public static final class Builder
+    {
+
+        Optional<ZonedDateTime> predicateLowerTimeBound;
+        Optional<ZonedDateTime> predicateUpperTimeBound;
+
+        public Builder()
+        {
+            // Empty constructor
+        }
+
+        public Builder(PrometheusPredicateTimeInfo prometheusPredicateTimeInfo)
+        {
+            this.predicateLowerTimeBound = prometheusPredicateTimeInfo.predicateLowerTimeBound;
+            this.predicateUpperTimeBound = prometheusPredicateTimeInfo.predicateUpperTimeBound;
+        }
+
+        public PrometheusPredicateTimeInfo build()
+        {
+            requireNonNull(predicateLowerTimeBound, "must set a lower time bound for predicate time info");
+            requireNonNull(predicateUpperTimeBound, "must set a upper time bound for predicate time info");
+            return new PrometheusPredicateTimeInfo(this);
+        }
+    }
+}

--- a/presto-prometheus/src/main/java/io/prestosql/plugin/prometheus/PrometheusSplitManager.java
+++ b/presto-prometheus/src/main/java/io/prestosql/plugin/prometheus/PrometheusSplitManager.java
@@ -13,8 +13,10 @@
  */
 package io.prestosql.plugin.prometheus;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import io.airlift.units.Duration;
+import io.prestosql.spi.connector.ColumnHandle;
 import io.prestosql.spi.connector.ConnectorSession;
 import io.prestosql.spi.connector.ConnectorSplit;
 import io.prestosql.spi.connector.ConnectorSplitManager;
@@ -23,6 +25,10 @@ import io.prestosql.spi.connector.ConnectorTableHandle;
 import io.prestosql.spi.connector.ConnectorTransactionHandle;
 import io.prestosql.spi.connector.FixedSplitSource;
 import io.prestosql.spi.connector.TableNotFoundException;
+import io.prestosql.spi.predicate.Domain;
+import io.prestosql.spi.predicate.Marker;
+import io.prestosql.spi.predicate.TupleDomain;
+import io.prestosql.spi.type.TimestampType;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.message.BasicNameValuePair;
@@ -33,10 +39,15 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -75,7 +86,8 @@ public class PrometheusSplitManager
         generateTimesForSplits(
                 PrometheusTimeMachine.now(),
                 prometheusClient.config.getMaxQueryRangeDuration(),
-                prometheusClient.config.getQueryChunkSizeDuration())
+                prometheusClient.config.getQueryChunkSizeDuration(),
+                table)
                 .forEach(time -> {
                     try {
                         splits.add(new PrometheusSplit(buildQuery(prometheusClient.config.getPrometheusURI(),
@@ -108,15 +120,22 @@ public class PrometheusSplitManager
      * Utility method to get the end times in decimal seconds that divide up the query into chunks
      * The times will be used in queries to Prometheus like: `http://localhost:9090/api/v1/query?query=up[21d]&time=1568229904.000"`
      * ** NOTE: Prometheus instant query wants the duration and end time specified.
+     * We use now() for the defaultUpperBound when none is specified, for instance, from predicate pushdown
      *
-     * @param now                       a LocalDateTime likely from PrometheusTimeMachine class for testability
+     * @param defaultUpperBound         a LocalDateTime likely from PrometheusTimeMachine class for testability
      * @param maxQueryRangeDurationStr  a String like `21d`
      * @param queryChunkSizeDurationStr a String like `1d`
      * @return list of end times as decimal epoch seconds, like ["1568053244.143", "1568926595.321"]
      */
-    protected static List<String> generateTimesForSplits(LocalDateTime now, String maxQueryRangeDurationStr, String queryChunkSizeDurationStr)
+    protected static List<String> generateTimesForSplits(LocalDateTime defaultUpperBound, String maxQueryRangeDurationStr, String queryChunkSizeDurationStr, PrometheusTable table)
     {
-        java.time.Duration maxQueryRangeDuration = java.time.Duration.ofMillis(Duration.valueOf(maxQueryRangeDurationStr).toMillis());
+        Optional<PrometheusPredicateTimeInfo> predicateRange = table.getPredicate()
+                .flatMap(predicate -> determinePredicateTimes(predicate));
+
+        EffectiveLimits effectiveLimits = new EffectiveLimits(defaultUpperBound, maxQueryRangeDurationStr, predicateRange);
+        ZonedDateTime upperBound = effectiveLimits.getUpperBound();
+        java.time.Duration maxQueryRangeDuration = effectiveLimits.getMaxQueryRangeDuration();
+
         java.time.Duration queryChunkSizeDuration = java.time.Duration.ofMillis(Duration.valueOf(queryChunkSizeDurationStr).toMillis());
         if (maxQueryRangeDuration.isNegative()) {
             throw new IllegalArgumentException("max-query-range-duration may not be negative");
@@ -130,18 +149,63 @@ public class PrometheusSplitManager
         BigDecimal maxQueryRangeDecimal = BigDecimal.valueOf(maxQueryRangeDuration.getSeconds()).add(BigDecimal.valueOf(maxQueryRangeDuration.getNano(), 9));
         BigDecimal queryChunkSizeDecimal = BigDecimal.valueOf(queryChunkSizeDuration.getSeconds()).add(BigDecimal.valueOf(queryChunkSizeDuration.getNano(), 9));
 
-        int numChunks = maxQueryRangeDecimal.divide(queryChunkSizeDecimal).setScale(0, RoundingMode.UP).intValue();
+        int numChunks = maxQueryRangeDecimal.divide(queryChunkSizeDecimal, 0, RoundingMode.UP).intValue();
 
         return Lists.reverse(IntStream.range(0, numChunks).mapToObj(n -> {
-            long endTime = now.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli() -
+            long endTime = upperBound.toInstant().toEpochMilli() -
                     n * queryChunkSizeDuration.toMillis() - n * OFFSET_MILLIS;
             return endTime;
         }).map(endTimeMilli -> decimalSecondString(endTimeMilli)).collect(Collectors.toList()));
     }
 
+    protected static Optional<PrometheusPredicateTimeInfo> determinePredicateTimes(TupleDomain<ColumnHandle> predicate)
+    {
+        Optional<Map<ColumnHandle, Domain>> maybeColumnHandleDomainMap = predicate.getDomains();
+        Optional<Set<ColumnHandle>> maybeKeySet = maybeColumnHandleDomainMap.map(columnHandleDomainMap -> columnHandleDomainMap.keySet());
+        Optional<Set<ColumnHandle>> maybeOnlyPromColHandles = maybeKeySet.map(keySet -> keySet.stream()
+                .filter(columnHandle -> columnHandle instanceof PrometheusColumnHandle).collect(Collectors.toSet()));
+        Optional<Set<ColumnHandle>> maybeOnlyTimeStampColumnHandles = maybeOnlyPromColHandles.map(columnHandles -> columnHandles.stream()
+                .filter(colHandle -> ((PrometheusColumnHandle) colHandle).getColumnType() instanceof TimestampType &&
+                        ((PrometheusColumnHandle) colHandle).getColumnName().equals("timestamp")).collect(Collectors.toSet()));
+
+        // below we have a set of ColumnHandle that are all PrometheusColumnHandle AND of TimestampType wrapped in Optional: maybeOnlyTimeStampColumnHandles
+        // the ColumnHandles in maybeOnlyTimeStampColumnHandles are keys to the map maybeColumnHandleDomainMap
+        // and the values in that map are Domains which hold the timestamp predicate range info
+        Map<ColumnHandle, Domain> columnHandleDomainMap = maybeColumnHandleDomainMap.orElse(ImmutableMap.of());
+        Optional<Set<Domain>> maybeTimeDomains = maybeOnlyTimeStampColumnHandles
+                .map(columnHandles -> columnHandles.stream().map(colHandle -> columnHandleDomainMap.get(colHandle)).collect(Collectors.toSet()));
+        return processTimeDomains(maybeTimeDomains);
+    }
+
+    private static Optional<PrometheusPredicateTimeInfo> processTimeDomains(Optional<Set<Domain>> maybeTimeDomains)
+    {
+        return maybeTimeDomains.map(timeDomains -> {
+            PrometheusPredicateTimeInfo.Builder timeInfoBuilder = PrometheusPredicateTimeInfo.builder();
+            timeDomains.stream()
+                    .forEach(domain -> {
+                        if (!domain.getValues().getRanges().getSpan().includes(Marker.lowerUnbounded(TimestampType.TIMESTAMP))) {
+                            timeInfoBuilder.predicateLowerTimeBound = Optional.of(ZonedDateTime.ofInstant(Instant.ofEpochMilli(
+                                    (long) domain.getValues().getRanges().getSpan().getLow().getValue()),
+                                    ZoneId.systemDefault()));
+                        }
+                        if (!domain.getValues().getRanges().getSpan().includes(Marker.upperUnbounded(TimestampType.TIMESTAMP))) {
+                            timeInfoBuilder.predicateUpperTimeBound = Optional.of(ZonedDateTime.ofInstant(Instant.ofEpochMilli(
+                                    (long) domain.getValues().getRanges().getSpan().getHigh().getValue()),
+                                    ZoneId.systemDefault()));
+                        }
+                    });
+            return timeInfoBuilder.build();
+        });
+    }
+
     static String decimalSecondString(long millis)
     {
         return new BigDecimal(Long.toString(millis)).divide(new BigDecimal(1000L)).toPlainString();
+    }
+
+    static long longFromDecimalSecondString(String decimalString)
+    {
+        return new BigDecimal(decimalString).multiply(new BigDecimal(1000L)).longValueExact();
     }
 
     static long timeUnitsToSeconds(String timeWithUnits)
@@ -152,5 +216,70 @@ public class PrometheusSplitManager
     static long timeUnitsToMillis(String timeWithUnits)
     {
         return Duration.valueOf(timeWithUnits).toMillis();
+    }
+
+    private static class EffectiveLimits
+    {
+        private ZonedDateTime upperBound;
+        private java.time.Duration maxQueryRangeDuration;
+
+        /**
+         * If no upper bound is specified by the predicate, we use the time now() as the defaultUpperBound
+         * if predicate LOWER bound is set AND predicate UPPER bound is set:
+         * max duration          = upper bound - lower bound
+         * effective upper bound = predicate upper bound
+         * if predicate LOWER bound is NOT set AND predicate UPPER bound is set:
+         * max duration          = config max duration
+         * effective upper bound = predicate upper bound
+         * if predicate LOWER bound is set AND predicate UPPER bound is NOT set:
+         * max duration          = defaultUpperBound - lower bound
+         * effective upper bound = defaultUpperBound
+         * if predicate LOWER bound is NOT set AND predicate UPPER bound is NOT set:
+         * max duration          = config max duration
+         * effective upper bound = defaultUpperBound
+         *
+         * @param defaultUpperBound        If no upper bound is specified by the predicate, we use the time now() as the defaultUpperBound
+         * @param maxQueryRangeDurationStr likely from config properties
+         * @param maybePredicateRange      Optional of pushed down predicate values for high and low timestamp values
+         */
+        public EffectiveLimits(LocalDateTime defaultUpperBound, String maxQueryRangeDurationStr, Optional<PrometheusPredicateTimeInfo> maybePredicateRange)
+        {
+            ZonedDateTime defaultUpperBoundZoned = ZonedDateTime.of(defaultUpperBound, ZoneId.systemDefault());
+
+            if (maybePredicateRange.isPresent()) {
+                if (maybePredicateRange.get().predicateUpperTimeBound.isPresent()) {
+                    // predicate upper bound set
+                    upperBound = maybePredicateRange.get().predicateUpperTimeBound.get();
+                }
+                else {
+                    // predicate upper bound NOT set
+                    upperBound = defaultUpperBoundZoned;
+                }
+                // here we're just working out the max duration using the above upperBound for upper bound
+                if (maybePredicateRange.get().predicateLowerTimeBound.isPresent()) {
+                    // predicate lower bound set
+                    maxQueryRangeDuration = java.time.Duration.between(maybePredicateRange.get().predicateLowerTimeBound.get(), upperBound);
+                }
+                else {
+                    // predicate lower bound NOT set
+                    maxQueryRangeDuration = java.time.Duration.ofMillis(Duration.valueOf(maxQueryRangeDurationStr).toMillis());
+                }
+            }
+            else {
+                // no predicate set, so no predicate value for upper bound, use defaultUpperBound (possibly now()) for upper bound and config for max durations
+                upperBound = defaultUpperBoundZoned;
+                maxQueryRangeDuration = java.time.Duration.ofMillis(Duration.valueOf(maxQueryRangeDurationStr).toMillis());
+            }
+        }
+
+        public ZonedDateTime getUpperBound()
+        {
+            return upperBound;
+        }
+
+        public java.time.Duration getMaxQueryRangeDuration()
+        {
+            return maxQueryRangeDuration;
+        }
     }
 }

--- a/presto-prometheus/src/main/java/io/prestosql/plugin/prometheus/PrometheusTable.java
+++ b/presto-prometheus/src/main/java/io/prestosql/plugin/prometheus/PrometheusTable.java
@@ -16,9 +16,12 @@ package io.prestosql.plugin.prometheus;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
+import io.prestosql.spi.connector.ColumnHandle;
 import io.prestosql.spi.connector.ColumnMetadata;
+import io.prestosql.spi.predicate.TupleDomain;
 
 import java.util.List;
+import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Strings.isNullOrEmpty;
@@ -29,6 +32,7 @@ public class PrometheusTable
     private final String name;
     private List<PrometheusColumn> columns;
     private List<ColumnMetadata> columnsMetadata;
+    private Optional<TupleDomain<ColumnHandle>> predicate = Optional.empty();
 
     @JsonCreator
     public PrometheusTable(
@@ -60,5 +64,15 @@ public class PrometheusTable
     public List<ColumnMetadata> getColumnsMetadata()
     {
         return columnsMetadata;
+    }
+
+    public Optional<TupleDomain<ColumnHandle>> getPredicate()
+    {
+        return this.predicate;
+    }
+
+    public void setPredicate(Optional<TupleDomain<ColumnHandle>> predicate)
+    {
+        this.predicate = predicate;
     }
 }

--- a/presto-prometheus/src/test/java/io/prestosql/plugin/prometheus/TestPrometheusTimestampDeserializer.java
+++ b/presto-prometheus/src/test/java/io/prestosql/plugin/prometheus/TestPrometheusTimestampDeserializer.java
@@ -26,10 +26,8 @@ public class TestPrometheusTimestampDeserializer
     public void testDeserializeTimestamp()
     {
         ZonedDateTime now = ZonedDateTime.now();
-        String nowEpochInSecondsStr = String.valueOf(now.toInstant().getEpochSecond());
-        long nowEpochNanos = now.toInstant().getNano();
-        String nowEpochMillisStr = String.valueOf(nowEpochNanos).substring(0, 3);
-        String nowTimeStr = nowEpochInSecondsStr + "." + nowEpochMillisStr;
+        long nowEpochMillis = now.toInstant().toEpochMilli();
+        String nowTimeStr = PrometheusSplitManager.decimalSecondString(nowEpochMillis);
         Timestamp nowTimestampActual = PrometheusTimestampDeserializer.decimalEpochTimestampToSQLTimestamp(nowTimeStr);
         assertEquals(nowTimestampActual,
                 new Timestamp(now.toInstant().toEpochMilli()));


### PR DESCRIPTION
Initial support for predicate push-down. Which in this case means: taking WHERE clause references limiting the timestamp range desired and interpreting them in conjunction with config properties into resultant limits for the generated Prometheus query.