### PR TITLE
Dockerfile: Fix the problem with podman not evaluating the PRESTO_VERION variable correctly.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -106,6 +106,9 @@ RUN mkdir -p /opt/presto
 ENV PRESTO_VERSION 322
 ENV PRESTO_HOME /opt/presto/presto-server
 ENV PRESTO_CLI /opt/presto/presto-cli
+# Note: podman was having difficulties evaluating the PRESTO_VERSION
+# environment variables: https://github.com/containers/libpod/issues/4878
+ARG PRESTO_VERSION=${PRESTO_VERSION}
 ENV PROMETHEUS_JMX_EXPORTER /opt/jmx_exporter/jmx_exporter.jar
 ENV TERM linux
 ENV HOME /opt/presto

--- a/Dockerfile.okd
+++ b/Dockerfile.okd
@@ -105,6 +105,9 @@ RUN mkdir -p /opt/presto
 ENV PRESTO_VERSION 322
 ENV PRESTO_HOME /opt/presto/presto-server
 ENV PRESTO_CLI /opt/presto/presto-cli
+# Note: podman was having difficulties evaluating the PRESTO_VERSION
+# environment variables: https://github.com/containers/libpod/issues/4878
+ARG PRESTO_VERSION=${PRESTO_VERSION}
 ENV PROMETHEUS_JMX_EXPORTER /opt/jmx_exporter/jmx_exporter.jar
 ENV TERM linux
 ENV HOME /opt/presto

--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -48,6 +48,9 @@ RUN mkdir -p /opt/presto
 ENV PRESTO_VERSION 315.0
 ENV PRESTO_HOME /opt/presto/presto-server
 ENV PRESTO_CLI /opt/presto/presto-cli
+# Note: podman was having difficulties evaluating the PRESTO_VERSION
+# environment variables: https://github.com/containers/libpod/issues/4878
+ARG PRESTO_VERSION=${PRESTO_VERSION}
 ENV PROMETHEUS_JMX_EXPORTER /opt/jmx_exporter/jmx_exporter.jar
 ENV TERM linux
 ENV HOME /opt/presto


### PR DESCRIPTION
It looks like the more recent buldah releases do not properly evaluate this environment variable when running the `COPY --from=...` command, while docker does.